### PR TITLE
Update FoxLoader + fix client-side crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,7 @@ build/
 !**/src/test/**/build/
 
 ### IntelliJ IDEA ###
-.idea/modules.xml
-.idea/jarRepositories.xml
-.idea/compiler.xml
-.idea/libraries/
+.idea
 *.iws
 *.iml
 *.ipr

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url 'https://jitpack.io/' }
     }
     dependencies {
-        classpath('com.github.Fox2Code.FoxLoader:dev:1.2.19')
+        classpath('com.fox2code.FoxLoader:dev:1.2.28')
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.jvmargs=-Xmx2G -XX:-UseGCOverheadLimit -Dfile.encoding=UTF-8
+org.gradle.parallel=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Sep 18 15:59:06 PDT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/client/java/com/jellied/gamerules/GamerulesClient.java
+++ b/src/client/java/com/jellied/gamerules/GamerulesClient.java
@@ -103,6 +103,10 @@ public class GamerulesClient extends GamerulesMod implements ClientMod {
         }
 
         worldGamerules = ((WorldInfoAccessorClient) world.worldInfo).getGamerules();
+        if (worldGamerules == null) {
+            ((WorldInfoAccessorClient) world.worldInfo)
+                    .setGamerules(worldGamerules = new NBTTagCompound());
+        }
 
         // Set defaults
         for (Map.Entry<String, Integer> set : GAMERULE_DEFAULTS.entrySet()) {

--- a/src/client/java/com/jellied/gamerules/client/mixins/WorldInfoMixin.java
+++ b/src/client/java/com/jellied/gamerules/client/mixins/WorldInfoMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class WorldInfoMixin implements WorldInfoAccessorClient {
     private NBTTagCompound gamerulesTag;
 
-    @Inject(method = "<init>", at = @At("TAIL"))
+    @Inject(method = "<init>*", at = @At("TAIL"))
     public void onWorldInfoConstructedWithTag(NBTTagCompound tag, CallbackInfo ci) {
         // System.out.println("New world info!");
 
@@ -37,7 +37,9 @@ public abstract class WorldInfoMixin implements WorldInfoAccessorClient {
 
     @Inject(method = "updateTagCompound", at = @At("TAIL"))
     public void onWorldInfoUpdated(NBTTagCompound newTag, NBTTagCompound plrTag, CallbackInfo ci) {
-        newTag.setCompoundTag("jelliedgamerules", gamerulesTag);
+        if (gamerulesTag != null) {
+            newTag.setCompoundTag("jelliedgamerules", gamerulesTag);
+        }
     }
 
     @Override

--- a/src/server/java/com/jellied/gamerules/GamerulesServer.java
+++ b/src/server/java/com/jellied/gamerules/GamerulesServer.java
@@ -49,6 +49,10 @@ public class GamerulesServer extends GamerulesMod implements ServerMod {
 
     public static void onWorldInit(World world) {
         worldGamerules = ((WorldInfoAccessor) world.getWorldInfo()).getGamerules();
+        if (worldGamerules == null) {
+            ((WorldInfoAccessor) world.getWorldInfo())
+                    .setGamerules(worldGamerules = new NBTTagCompound());
+        }
 
         // Set defaults
         for (Map.Entry<String, Integer> set : GAMERULE_DEFAULTS.entrySet()) {


### PR DESCRIPTION
Someone game kept crashing because of this mod, important part of crash:
```
java.lang.NullPointerException: Cannot invoke "net.minecraft.src.game.nbt.NBTTagCompound.setKey(String)" because "nBTTagCompound" is null 
    at net.minecraft.src.game.nbt.NBTTagCompound.setCompoundTag(NBTTagCompound.java:117)
    at net.minecraft.src.game.level.WorldInfo.handler$zbn000$onWorldInfoUpdated(WorldInfo.java:540)
    at net.minecraft.src.game.level.WorldInfo.updateTagCompound(WorldInfo.java:163)
```
Also I updated the FoxLoader runtime while I was at it.
